### PR TITLE
fix encoding issues on python 3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ dependencies:
     - .pyenv
     - /opt/circleci/.pyenv/versions/2.6.8
   override:
+    - sudo apt-get update
+    - sudo apt-get install --yes wamerican-small
     # the others are local...
     - pyenv install -ks 2.6.8
     - pip install tox tox-pyenv

--- a/shentry.py
+++ b/shentry.py
@@ -223,12 +223,15 @@ def read_snippet(fo, max_length):
     if length > max_length:
         top = int(max_length / 2) - 8
         bottom = max_length - top
-        rv.append(fo.read(top))
+        top = fo.read(top).decode('utf-8', 'ignore')
+        rv.append(top)
+        if not top.endswith('\n'):
+            rv.append('\n')
         rv.append('\n[snip]\n')
         fo.seek(-1 * bottom, os.SEEK_END)
-        rv.append(fo.read(bottom))
+        rv.append(fo.read(bottom).decode('utf-8', 'ignore'))
     else:
-        rv.append(fo.read())
+        rv.append(fo.read().decode('utf-8', 'ignore'))
         read_all = True
     return ''.join(rv), read_all
 
@@ -258,8 +261,8 @@ def main(argv=None):
     working_dir = None
     try:
         working_dir = tempfile.mkdtemp()
-        with open(os.path.join(working_dir, 'stdout'), 'w+') as stdout:
-            with open(os.path.join(working_dir, 'stderr'), 'w+') as stderr:
+        with open(os.path.join(working_dir, 'stdout'), 'w+b') as stdout:
+            with open(os.path.join(working_dir, 'stderr'), 'w+b') as stderr:
                 start_time = time.time()
                 p = subprocess.Popen(full_command, stdout=stdout, stderr=stderr, shell=False,
                                      preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -75,5 +75,6 @@ def test_main(mocker, tmpdir):
             'duration': ANY,
             'PATH': 'A_PATH',
             'returncode': 1,
+            '_sent_with': ANY,
         }
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,197 @@
+import collections
+import threading
+import subprocess
+import os
+import json
+import mock
+import pwd
+import socket
+
+import pytest
+
+try:
+    from BaseHTTPServer import HTTPServer
+    from BaseHTTPServer import BaseHTTPRequestHandler
+except ImportError:
+    raise
+    from http.server import HTTPServer
+    from http.server import BaseHTTPRequestHandler
+
+
+Request = collections.namedtuple('Request', ['command', 'path', 'headers', 'body'])
+
+
+class SentryHTTPServer(HTTPServer):
+    timeout = 0.1
+
+    def __init__(self, *args, **kwargs):
+        requests = kwargs.pop('requests')
+        HTTPServer.__init__(self, *args, **kwargs)
+        self.requests = requests
+
+    def handle_timeout(self):
+        pass
+
+
+class SentryHTTPRequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body_len = int(self.headers.get('Content-Length', '0'))
+        body = self.rfile.read(body_len)
+        request = Request(command=self.command, path=self.path, headers=dict(self.headers.items()), body=body)
+        self.server.requests.append(request)
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        body = json.dumps({'status': 'ok'}).encode('utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class TestHTTPServer(object):
+    def __init__(self):
+        self.running = False
+        self.address = None
+        self._thread = None
+        self.requests = []
+        self._started = threading.Condition()
+
+    @property
+    def uri(self):
+        return 'http://sentry:password@{0}/'.format(':'.join(map(str, self.address)))
+
+    def run(self):
+        self.running = True
+        httpd = SentryHTTPServer(('127.0.0.1', 0), SentryHTTPRequestHandler, requests=self.requests)
+        self.address = httpd.server_address
+        self._started.acquire()
+        self._started.notify_all()
+        self._started.release()
+        while self.running:
+            httpd.handle_request()
+
+    def start(self):
+        t = threading.Thread(target=self.run)
+        self._thread = t
+        t.start()
+        self._started.acquire()
+        self._started.wait()
+        self._started.release()
+
+    def stop(self):
+        if self.running:
+            self.running = False
+            self._thread.join()
+
+
+@pytest.yield_fixture
+def http_server():
+    t_s = TestHTTPServer()
+    t_s.start()
+    yield t_s
+    t_s.stop()
+
+
+FAIL_NO_OUTPUT = '''#!/bin/bash
+
+exit 1
+'''
+
+FAIL_LONG_OUTPUT = '''#!/bin/bash
+
+head -c 2000 /usr/share/dict/words
+tail -c 2000 /usr/share/dict/words >&2
+
+exit 1
+'''
+
+
+@pytest.fixture
+def scripts(tmpdir):
+    paths = {}
+    for script in ('FAIL_NO_OUTPUT', 'FAIL_LONG_OUTPUT'):
+        with open(os.path.join(str(tmpdir), script), 'w') as f:
+            f.write(globals()[script])
+            os.fchmod(f.fileno(), 0o700)
+        paths[script] = os.path.join(str(tmpdir), script)
+    return paths
+
+
+def test_no_output(http_server, scripts):
+    subprocess.check_call(
+        ['shentry.py', scripts['FAIL_NO_OUTPUT']],
+        env={
+            'SHELL_SENTRY_DSN': http_server.uri
+        }
+    )
+    # ensure that the http server has processed all requests
+    http_server.stop()
+    assert len(http_server.requests) == 1
+    req = http_server.requests[0]
+    assert req.command == 'POST'
+    body = json.loads(req.body.decode('utf-8'))
+    assert body == {
+        'device': mock.ANY,
+        'event_id': mock.ANY,
+        'extra': {
+            'PATH': mock.ANY,
+            '_sent_with': mock.ANY,
+            'command': scripts['FAIL_NO_OUTPUT'],
+            'duration': mock.ANY,
+            'load_average_at_exit': mock.ANY,
+            'returncode': 1,
+            'shell': '/bin/sh',
+            'start_time': mock.ANY,
+            'username': pwd.getpwuid(os.getuid()).pw_name
+        },
+        'fingerprint': mock.ANY,
+        'message': 'Command `{0}` failed with code 1.\n'.format(scripts['FAIL_NO_OUTPUT']),
+        'platform': 'other',
+        'tags': [
+            ['server_name', socket.gethostname()],
+            ['logger', ''],
+            ['level', 'error']
+        ],
+        'timestamp': mock.ANY,
+    }
+
+
+def test_multi_kb_output(http_server, scripts):
+    subprocess.check_call(
+        ['shentry.py', scripts['FAIL_LONG_OUTPUT']],
+        env={
+            'SHELL_SENTRY_DSN': http_server.uri
+        }
+    )
+    # ensure that the http server has processed all requests
+    http_server.stop()
+    assert len(http_server.requests) == 1
+    req = http_server.requests[0]
+    assert req.command == 'POST'
+    body = json.loads(req.body.decode('utf-8'))
+    assert body == {
+        'device': mock.ANY,
+        'event_id': mock.ANY,
+        'extra': {
+            'PATH': mock.ANY,
+            '_sent_with': mock.ANY,
+            'command': scripts['FAIL_LONG_OUTPUT'],
+            'duration': mock.ANY,
+            'load_average_at_exit': mock.ANY,
+            'returncode': 1,
+            'shell': '/bin/sh',
+            'start_time': mock.ANY,
+            'username': pwd.getpwuid(os.getuid()).pw_name
+        },
+        'fingerprint': mock.ANY,
+        'message': mock.ANY,
+        'platform': 'other',
+        'tags': [
+            ['server_name', socket.gethostname()],
+            ['logger', ''],
+            ['level', 'error']
+        ],
+        'timestamp': mock.ANY,
+    }
+    assert body['message'].startswith(
+        'Command `{0}` failed with code 1.\n\nExcerpt of stderr:\n'.format(scripts['FAIL_LONG_OUTPUT'])
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,7 +46,7 @@ class SentryHTTPRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 
-class TestHTTPServer(object):
+class UUTHTTPServer(object):
     def __init__(self):
         self.running = False
         self.address = None
@@ -84,7 +84,7 @@ class TestHTTPServer(object):
 
 @pytest.yield_fixture
 def http_server():
-    t_s = TestHTTPServer()
+    t_s = UUTHTTPServer()
     t_s.start()
     yield t_s
     t_s.stop()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,6 @@ try:
     from BaseHTTPServer import HTTPServer
     from BaseHTTPServer import BaseHTTPRequestHandler
 except ImportError:
-    raise
     from http.server import HTTPServer
     from http.server import BaseHTTPRequestHandler
 


### PR DESCRIPTION
Python 3 doesn't let you seek a file opened in "text" mode (the default, where it's auto-decoded as utf-8) with a byte offset. This makes sense, since otherwise you might jump into the middle of a utf-8 character.

This commit changes the stdout/stderr files to be opened in binary mode so that the seeks to read the beginning/end of the stdout/stderr file work and to manually decode as utf-8, throwing away any partial chars.

Tested manually with a command that generates more than 1KB of output.