### PR TITLE
Make Shentry read from $SENTRY_DSN in addition to $SHELL_SENTRY_DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ status 0 if events are able to be sent to Sentry.
 
 It reads its configuration from the environment variable `$SHELL_SENTRY_DSN`
 and, if such a variable is found, removes it from the environment before
-calling the wrapped program. If the environment variable is not present or
-is empty, shentry will try to read a DSN from `/etc/shentry_dsn`. If no DSN
+calling the wrapped program. If that environment variable is not present, shentry will look
+for `$SENTRY_DSN`. If neither of the environment variables are present or btoh
+are empty, shentry will try to read a DSN from `/etc/shentry_dsn`. If no DSN
 can be found, the wrapped will have normal behavior (stdout/stderr will go
 to their normal file descriptors, exit code will be passed through, etc).
 

--- a/shentry.py
+++ b/shentry.py
@@ -126,6 +126,8 @@ class SimpleSentryClient(object):
     def new_from_environment(cls):
         dsn = os.environ.pop('SHELL_SENTRY_DSN', '')
         if not dsn:
+            dsn = os.environ.pop('SENTRY_DSN', '')
+        if not dsn:
             dsn = read_systemwide_config()
         if not dsn:
             return None
@@ -214,7 +216,7 @@ def show_usage():
     print('Usage: shentry [-c] command [...]', file=sys.stderr)
     print('', file=sys.stderr)
     print('Runs COMMAND, sending the output to Sentry if it exits non-0', file=sys.stderr)
-    print('Takes sentry DSN from $SHELL_SENTRY_DSN or /etc/shentry_dsn', file=sys.stderr)
+    print('Takes sentry DSN from $SHELL_SENTRY_DSN, $SENTRY_DSN, or /etc/shentry_dsn', file=sys.stderr)
 
 
 def read_snippet(fo, max_length):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,6 +41,14 @@ class TestSimpleSentryClient(object):
         assert client.secret == 'priv'
         assert client.project_id == '1'
 
+    def test_new_from_environment_regular_dsn(self, mocker):
+        mocker.patch.dict('os.environ', {'SENTRY_DSN': 'https://pub:priv@sentry.test/3'})
+        client = shentry.SimpleSentryClient.new_from_environment()
+        assert client.uri == 'https://sentry.test/api/3/store/'
+        assert client.public == 'pub'
+        assert client.secret == 'priv'
+        assert client.project_id == '3'
+
     def test_new_from_environment_with_file(self, mocker):
         mocker.patch.dict('os.environ', {'SHELL_SENTRY_DSN': ''})
         mocker.patch.object(shentry, 'read_systemwide_config', return_value='https://pub:priv@sentry.test/2')


### PR DESCRIPTION
I think we had good reasons at the time for requiring a separate DSN for cron stuff, but it doesn't seem as valid any more.