### PR TITLE
Please don't pop SENTRY_DSN from the environment.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.4.1
+-----
+- Don't pop `$SENTRY_DSN` from the environment when we use it
+
 0.4.0
 -----
 - pass through SIGTERM, SIGQUIT, and SIGINT to the child process

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="shentry",
-    version="0.4.0",
+    version="0.4.1",
     author="EasyPost",
     author_email="oss@easypost.com",
     url="https://github.com/easypost/shentry",

--- a/shentry.py
+++ b/shentry.py
@@ -126,7 +126,7 @@ class SimpleSentryClient(object):
     def new_from_environment(cls):
         dsn = os.environ.pop('SHELL_SENTRY_DSN', '')
         if not dsn:
-            dsn = os.environ.pop('SENTRY_DSN', '')
+            dsn = os.environ.get('SENTRY_DSN', '')
         if not dsn:
             dsn = read_systemwide_config()
         if not dsn:


### PR DESCRIPTION
Merge this or #15, not both.

Removing SENTRY_DSN breaks anything that would also use it to raise sentries internally.

closes #13 